### PR TITLE
Python3で開発用ローカルサーバを立ち上げるために修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 ## OthloHackathon
 
 ## How to Use
-1. clone
-2. `npm install`
-3. `npm run build`で、assets/scssを、assets/cssに初期ビルド。
-4. `npm run watch`でscssの変更を監視 & サーバ立ち上げ（`localhost:8080`）
-5.  `localhost:8080`にアクセス
+1. `git clone https://github.com/OthloTech/OthloHackathon.git`
+2. `git checkout feature/2017`
+3. `npm install`
+4. `npm start`    // 変更を検知 & サーバ立ち上げ
+5. `localhost:8080`にアクセス
 
+## Requirements
+- Python3
 
 ## サイトイメージ
 ![othlohack](https://raw.githubusercontent.com/OthloTech/OthloHackathon/master/othlohack.png)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node-sass": "^3.7.0"
   },
   "scripts": {
-    "watch": "npm run build; npm run watch-scss & npm run server",
+    "start": "npm run build; npm run watch-scss & npm run server",
     "build": "node-sass ./assets/scss --output ./assets/css",
     "watch-scss": "node-sass ./assets/scss --output ./assets/css -w",
     "server": "python3 -m http.server 8080"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "watch": "npm run build; npm run watch-scss & npm run server",
     "build": "node-sass ./assets/scss --output ./assets/css",
     "watch-scss": "node-sass ./assets/scss --output ./assets/css -w",
-    "server": "python -m SimpleHTTPServer 8080"
+    "server": "python3 -m http.server 8080"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## これは「Python3で開発ローカルサーバを立ち上げる」際の取り扱いを修正します。

### Python2ではSimpleHTTPServerを使います。ポート番号を省略すると8000が用いられます。

`$ python -m SimpleHTTPServer [ポート番号(デフォルトは8000)]`
### Python3ではhttp.serverを使います。

`$ python3 -m http.server [ポート番号(デフォルトは8000)]`