### PR TITLE
会場の画像についていた、ページトップに戻るだけのリンクを削除

### DIFF
--- a/2017.html
+++ b/2017.html
@@ -299,22 +299,22 @@
             <div class="row 150%">
               <div class="4u 12u(mobile)">
                 <section class="highlight">
-                  <a href="#" class="image featured"><img src="./images/venue/1.jpg" alt="" /></a>
-                  <h3><a href="#">名城Shake</a></h3>
+                  <a class="image featured"><img src="./images/venue/1.jpg" alt="" /></a>
+                  <h3>名城Shake</h3>
                   <p>ミーティングや開発に最適化された空間で、アイデアを形にしませんか。</p>
                 </section>
               </div>
               <div class="4u 12u(mobile)">
                 <section class="highlight">
-                  <a href="#" class="image featured"><img src="./images/venue/2.jpg" alt="" /></a>
-                  <h3><a href="#">名城大学 中庭</a></h3>
+                  <a class="image featured"><img src="./images/venue/2.jpg" alt="" /></a>
+                  <h3>名城大学 中庭</h3>
                   <p>ハッカソンで疲れたらこのきれいな芝生で寝るもよし。青空の下で開発するもよし。</p>
                 </section>
               </div>
               <div class="4u 12u(mobile)">
                 <section class="highlight">
-                  <a href="#" class="image featured"><img src="./images/venue/3.jpg" alt="" /></a>
-                  <h3><a href="#">名城大学 中庭</a></h3>
+                  <a class="image featured"><img src="./images/venue/3.jpg" alt="" /></a>
+                  <h3>名城大学 中庭</h3>
                   <p>疲れたら気分転換にここで鬼ごっこをやってみてもいいかもしれない(適当)。</p>
                 </section>
               </div>


### PR DESCRIPTION
HTML5 UPのテンプレートに最初からついていたリンクです。
大した問題ではないと思いますがなんとなく眺めてて気になったのでw

こっそりマージしちゃいましょう